### PR TITLE
Feature/ignore forbid set trace

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,14 @@
+[settings]
+case_sensitive=True
+combine_as_imports=True
+default_section=THIRDPARTY
+filter_files=True
+force_grid_wrap=0
+include_trailing_comma=True
+known_odoo=odoo
+line_length=120
+multi_line_output=3
+no_lines_before=FUTURE,STDLIB,THIRDPARTY,ODOO,FIRSTPARTY,LOCALFOLDER
+sections=FUTURE,STDLIB,THIRDPARTY,ODOO,FIRSTPARTY,LOCALFOLDER
+skip=__init__.py
+use_parentheses=True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,56 @@
+exclude: ^_lib/.*$|^_lib_static/.*$|^\.container/.*$|^\.om/.*$|^\.docs/.*$
 repos:
--   repo: https://github.com/traviswaelbro/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: master
     hooks:
-    -   id: forbid-git-conflicts
-    -   id: forbid-set-trace
+    - id: check-merge-conflict
+      name: Check for leftover merge conflicts
+      description: Check for files that contain merge conflict strings.
+      language: python
+      stages: [commit]
+    - id: trailing-whitespace
+      name: Trim Trailing Whitespace
+      language: python
+-   repo: https://github.com/pre-commit/mirrors-pylint
+    rev: master
+    hooks:
+    - id: pylint
+      name: Pylint
+      description: Lint files with Pylint to find errors/warnings
+      stages: [commit]
+      # Disable warnings that are sometimes unavoidable (such as shadowing core)
+      #   * This adds onto the disabled warnings from .pylintrc
+      args: ['--disable=abstract-method,bad-continuation,bare-except,broad-except,cell-var-from-loop,consider-iterating-dictionary,fixme,import-error,logging-format-interpolation,logging-not-lazy,missing-docstring,no-self-use,self-cls-assignment,too-many-arguments,too-many-boolean-expressions,too-many-branches,too-many-instance-attributes,too-many-locals,too-many-nested-blocks,too-many-public-methods,too-many-statements,unnecessary-pass,unused-argument,unused-import,unused-variable,wrong-import-order,wrong-import-position']
+-   repo: https://github.com/chewse/pre-commit-mirrors-pydocstyle
+    rev: master
+    hooks:
+    - id: pydocstyle
+      name: Pydocstyle
+      description: Find any missing docstrings
+      stages: [commit]
+      # Allow missing docstrings in module or class, but nowhere else
+      # http://www.pydocstyle.org/en/3.0.0/error_codes.html
+-   repo: https://github.com/myint/docformatter
+    rev: master
+    hooks:
+    - id: docformatter
+      name: Format Python Docstrings
+      description: Auto-format docstrings to match style guide.
+      stages: [commit]
+      args: [-i, --wrap-summaries=80, --wrap-descriptions=80, --pre-summary-newline, --make-summary-multi-line]
+-   repo: https://github.com/gobluestingray/pre-commit-hooks
+    rev: master
+    hooks:
+    - id: forbid-git-conflicts
+    - id: forbid-set-trace
+      types: [python]
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.8
+      args: [-l 120]
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.9.3
+    hooks:
+    - id: isort

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,0 +1,3 @@
+[pydocstyle]
+match = ^((?!test_).)*$
+select = D102,D103,D105,D106,D107

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,496 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+# extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+# ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=(__openerp__.py|__odoo.py__|__manifest__.py)
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+# init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=2
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+# load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+# unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# ** We are disabling missing docstring warnings because they are being handled
+#    by pydocstyle during pre-commits.
+disable=attribute-defined-outside-init,
+        bad-continuation,
+        duplicate-code,
+        logging-format-interpolation,
+        logging-fstring-interpolation,
+        missing-docstring,
+        missing-super-argument,
+        protected-access,
+        self-cls-assignment,
+        super-with-arguments,
+        too-few-public-methods,
+        too-many-lines,
+        wrong-import-order,
+        wrong-import-position
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+# enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+# evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+# msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+# output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+# class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+# class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#   Constants must be UPPER_CASE, with the exception of `_logger`
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|(_logger))$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+function-rgx=[a-z_][a-z0-9_]{2,40}$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=_,
+           __
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=yes
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+# inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#   Methods should start with a lowercase letter or underscore and may use only
+#   lowercase letters, numbers, or underscores after that point. They should be
+#   between 2 and 50 characters. The only exceptions are methods starting with
+#   `setUp` (such as `setUp` or `setUpClass` methods used in test classes).
+method-rgx=[a-z_][a-z0-9_]{2,50}|^setUp$
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+# module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+#   Only functions/classes starting with `_`, `test_`, `setUp`, OR "a capital
+#   letter" are exempt from docstring requirements. The "a capital letter"
+#   exemption is to prevent requiring class docstrings.
+no-docstring-rgx=^_|test_|^setUp|^[A-Z]
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#   Variables should start with a lowercase letter or underscore and may use
+#   only lowercase letters, numbers, or underscores after that point. They
+#   should be between 2 and 20 characters.
+# ** First part of the regex (before the bar) allows plain 3-character variables
+#    Second part sets the normal regex which requires snake_case
+variable-rgx=([a-z]{3,3}|[a-z_][a-z0-9_]{3,20})
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=LF
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=160
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+# no-space-check=trailing-comma,
+#                dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+# single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+# single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO,
+      TESTME
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+# spelling-dict=
+
+# List of comma separated words that should not be checked.
+# spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+# spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+# spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+# contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+# generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+# ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+# ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+# ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+# ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+# missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+# missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+# missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=_
+
+# Tells whether unused global variables should be treated as a violation.
+# allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+# callbacks=cb_,
+          # _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+# dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+# ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+# init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+# redefining-builtins-modules=six.moves,past.builtins,future.builtins,io
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+# defining-attr-methods=__init__,
+                      # __new__,
+                      # setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+# exclude-protected=_asdict,
+                  # _fields,
+                  # _replace,
+                  # _source,
+                  # _make
+
+# List of valid names for the first argument in a class method.
+# valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+# valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=8
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+ignored-modules=mock,
+                odoo,
+                openerp,
+                psycopg2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/README.md
+++ b/README.md
@@ -20,11 +20,34 @@ repos:
     -   id: forbid-set-trace
 ```
 
+### Disabling and Enabling Hooks within Files
+
+The below comments allow disabling and re-enabling of the `forbid-git-conflicts`
+and `forbid-set-trace` hooks, using comments to turn it off and on, similar
+to `black`'s `#fmt: off` and `#fmt: on`. These options can be useful for
+ignoring "bad content" that is being flagged as a false positive, such as
+comments, documentation, etc.
+
+```
+# forbid-git-conflicts: off
+"<<<<<<<"
+# forbid-git-conflicts: on
+```
+
+```
+# forbid-set-trace: off
+__import__("ipdb").set_trace()
+# forbid-set-trace: on
+```
+
 ---
 
 ## Supported Hooks
 
 ### forbid-git-conflicts
+
+<!-- forbid-git-conflicts: off (disable for the below content, without actually
+     displaying this on the readme page. -->
 
 Simple hook which iterates over all staged files to check for any lines that
 have left over Git conflict markers.

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,3 @@
+# pylint: disable=import-self
 from . import hooks
 from . import tests

--- a/hooks/__init__.py
+++ b/hooks/__init__.py
@@ -1,3 +1,4 @@
+# forbid-set-trace: off
 from . import forbid_git_conflicts
 from . import forbid_set_trace
 from . import helpers

--- a/hooks/forbid_set_trace.py
+++ b/hooks/forbid_set_trace.py
@@ -1,10 +1,20 @@
+# forbid-set-trace: off
 from __future__ import print_function
-import argparse, sys
-from .helpers import is_textfile
+import argparse
+import sys
 
+# This allows `is_textfile` to be imported properly in different environments
+try:
+    from .helpers import is_textfile
+except ImportError:
+    import helpers
 
-CONFLICT_STRINGS = ['pdb',
-                    'set_trace', ]
+    is_textfile = helpers.is_textfile
+
+CONFLICT_STRINGS = [
+    "pdb",
+    "set_trace",
+]
 
 
 def find_set_trace_conflicts(filename):
@@ -14,11 +24,13 @@ def find_set_trace_conflicts(filename):
     :param filename {str}: file name with relative path
     :return {bool}: True if forbidden code is found else False
     """
-    with open(filename, mode='r') as file_checked:
+    with open(filename, mode="r") as file_checked:
         conflicts = []
+        ignore = False
         for line_number, line in enumerate(file_checked, start=1):
-            if has_conflict(line):
-                num_spaces = ' ' * (6 - len(str(line_number)))
+            ignore = is_ignore_enabled(line, ignore)
+            if not ignore and has_conflict(line):
+                num_spaces = " " * (6 - len(str(line_number)))
                 conflicts.append("{}:{}{}{}".format(filename, line_number, num_spaces, line.lstrip()))
 
         return conflicts
@@ -34,7 +46,20 @@ def has_conflict(content):
         True if the provided content contains a match for any of the
         CONFLICT_STRINGS values.
     """
-    return any(conflict_string in content.rstrip('\n') for conflict_string in CONFLICT_STRINGS)
+    return any(conflict_string in content.rstrip("\n") for conflict_string in CONFLICT_STRINGS)
+
+
+def is_ignore_enabled(content, ignore):
+    """
+    Check if the provided content contains a match for any of the debugger
+    related values.
+
+    :param content {str}: content to be checked for conflicts
+    :param ignore {bool}: True if "ignore" is currently enabled, otherwise False
+    :return {bool}: True if the check should be enforced, otherwise false
+    """
+    flag = "on" if ignore else "off"
+    return not ignore if "forbid-set-trace: {}".format(flag) in content else ignore
 
 
 def main(argv=None):
@@ -42,32 +67,30 @@ def main(argv=None):
     Parse each line of the staged files to check for left over debugging imports
     or statements.
 
-    Errors will be thrown for any lines that contain:
-      - 'pdb'
-      - 'set_trace'
+    Errors will be thrown for any lines that contains one of the CONFLICT_STRINGS
 
     :return {int}: 1 if failure else 0
     """
     # Parse arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument('filenames', nargs='*', help='File names to check')
+    parser.add_argument("filenames", nargs="*", help="File names to check")
     args = parser.parse_args(argv)
     filenames = args.filenames
 
     # Find files with conflicts
-    text_files = [filename for filename in filenames if is_textfile(filename)]
+    python_files = [filename for filename in filenames if is_textfile(filename) and filename.endswith(".py")]
     files_with_conflicts = []
-    for text_file in text_files:
+    for text_file in python_files:
         files_with_conflicts += find_set_trace_conflicts(text_file)
 
     # Return response
     exit_code = 0
     if files_with_conflicts:
         exit_code = 1
-        print('Debuggers Detected in file(s): \n - {}'.format(' - '.join(files_with_conflicts)))
+        print("Debuggers Detected in file(s): \n - {}".format(" - ".join(files_with_conflicts)))
 
     return exit_code
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/hooks/helpers.py
+++ b/hooks/helpers.py
@@ -16,7 +16,7 @@ def is_textfile(filename, blocksize=512):
     """
     if any(filename.endswith(ext) for ext in KNOWN_BINARY_FILE_EXTS):
         return False
-    return is_text(open(filename, "rb").read(blocksize))
+    return is_text(open(filename, "rb").read(blocksize))  # pylint: disable=consider-using-with
 
 
 def is_text(content):

--- a/hooks/helpers.py
+++ b/hooks/helpers.py
@@ -1,7 +1,10 @@
 # Taken from: http://code.activestate.com/recipes/173220-test-if-a-file-or-string-is-text-or-binary/
 
-KNOWN_BINARY_FILE_EXTS = ['.pdf',
-                          '.pyc', ]
+KNOWN_BINARY_FILE_EXTS = [
+    ".pdf",
+    ".pyc",
+]
+
 
 def is_textfile(filename, blocksize=512):
     """
@@ -13,7 +16,8 @@ def is_textfile(filename, blocksize=512):
     """
     if any(filename.endswith(ext) for ext in KNOWN_BINARY_FILE_EXTS):
         return False
-    return is_text(open(filename, 'rb').read(blocksize))
+    return is_text(open(filename, "rb").read(blocksize))
+
 
 def is_text(content):
     """
@@ -27,7 +31,7 @@ def is_text(content):
         return True
     # Try to decode as UTF-8
     try:
-        content.decode('utf8')
+        content.decode("utf8")
     except UnicodeDecodeError:
         return False
     else:

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,30 @@
+# forbid-set-trace: off
 from setuptools import find_packages, setup
 
 setup(
-    name='pre-commit-hooks',
-    description='Hooks for pre-commit',
-    url='https://github.com/traviswaelbro/pre-commit-hooks',
-    version='0.0.1',
-
-    author='Travis Waelbroeck',
-    author_email='twaelbroeck@gmail.com',
-
-    platforms='linux',
+    name="pre-commit-hooks",
+    description="Hooks for pre-commit",
+    url="https://github.com/traviswaelbro/pre-commit-hooks",
+    version="0.0.1",
+    author="Travis Waelbroeck",
+    author_email="twaelbroeck@gmail.com",
+    platforms="linux",
     classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
-
-    packages=find_packages('.'),
+    packages=find_packages("."),
     entry_points={
-        'console_scripts': [
-            'forbid_git_conflicts = hooks.forbid_git_conflicts:main',
-            'forbid_set_trace = hooks.forbid_set_trace:main',
+        "console_scripts": [
+            "forbid_git_conflicts = hooks.forbid_git_conflicts:main",
+            "forbid_set_trace = hooks.forbid_set_trace:main",
         ],
     },
 )


### PR DESCRIPTION
## Include simple support for ignoring hooks flags

This allows disabling and re-enabling of the `forbid-git-conflicts` and `forbid-set-trace` hooks, using comments to turn it off and on, similar to `black`'s `#fmt: off` and `#fmt: on`.

These options can be useful for ignoring "bad content" that is being flagged as a false positive, such as comments, documentation, etc.

```
# forbid-git-conflicts: off
"<<<<<<<"
# forbid-git-conflicts: on
```

```
# forbid-set-trace: off
__import__("ipdb").set_trace()
# forbid-set-trace: on
```

### Notes:

- This release is tagged as `20210929-a`, which is the first tag for this repo.
- The "good stuff" is in the `helpers/` directory. Most of the other files are just copied in to improve code consistency. Reviewing this as separate commits might be helpful.
